### PR TITLE
ts-672 add cancel() in benchmark

### DIFF
--- a/src/test/scala/com/bwsw/tstreams/benchmark/ProducerBenchmark.scala
+++ b/src/test/scala/com/bwsw/tstreams/benchmark/ProducerBenchmark.scala
@@ -54,20 +54,22 @@ class ProducerBenchmark(address: String,
     *
     * @param iterations         amount of measurements
     * @param dataSize           size of data sent in each transaction
-    * @param withCheckpoint     if true, a checkpoint will be performed for each transaction
+    * @param cancelTransactions if true, each transaction will be cancelled,
+    *                           otherwise a checkpoint will be performed for each transaction
     * @param progressReportRate progress will be printed to the console after this number of iterations
     * @return measurement result
     */
   def run(iterations: Int,
           dataSize: Int = 100,
-          withCheckpoint: Boolean = true,
+          cancelTransactions: Boolean = false,
           progressReportRate: Int = 1000): ProducerBenchmark.Result = {
     val producer = factory.getProducer(stream, (0 until partitions).toSet)
     val data = (1 to dataSize).map(_.toByte).toArray
 
     val newTransaction = new ExecutionTimeMeasurement
     val send = createTimeMeasurementIf(dataSize > 0)
-    val checkpoint = createTimeMeasurementIf(withCheckpoint)
+    val checkpoint = createTimeMeasurementIf(!cancelTransactions)
+    val cancel = createTimeMeasurementIf(cancelTransactions)
     val progressBar =
       if (progressReportRate > 0) Some(new ProgressBar(iterations))
       else None
@@ -76,6 +78,7 @@ class ProducerBenchmark(address: String,
       val transaction = newTransaction(() => producer.newTransaction(NewProducerTransactionPolicy.ErrorIfOpened))
       send.foreach(_.apply(() => transaction.send(data)))
       checkpoint.foreach(_.apply(() => producer.checkpoint()))
+      cancel.foreach(_.apply(() => producer.cancel()))
 
       progressBar.foreach(_.show(i, progressReportRate))
     }
@@ -85,7 +88,8 @@ class ProducerBenchmark(address: String,
     ProducerBenchmark.Result(
       newTransaction = newTransaction.result,
       sendData = send.map(_.result),
-      checkpoint = checkpoint.map(_.result))
+      checkpoint = checkpoint.map(_.result),
+      cancel = cancel.map(_.result))
   }
 
   def close(): Unit =
@@ -103,12 +107,14 @@ object ProducerBenchmark extends App {
 
   case class Result(newTransaction: ExecutionTimeMeasurement.Result,
                     sendData: Option[ExecutionTimeMeasurement.Result] = None,
-                    checkpoint: Option[ExecutionTimeMeasurement.Result] = None) {
+                    checkpoint: Option[ExecutionTimeMeasurement.Result] = None,
+                    cancel: Option[ExecutionTimeMeasurement.Result] = None) {
 
     def toMap: Map[String, ExecutionTimeMeasurement.Result] = {
       Map("newTransaction" -> newTransaction) ++
         sendData.map(result => "sendData" -> result) ++
-        checkpoint.map(result => "checkpoint" -> result)
+        checkpoint.map(result => "checkpoint" -> result) ++
+        cancel.map(result => "cancel" -> result)
     }
   }
 

--- a/src/test/scala/com/bwsw/tstreams/benchmark/ProducerBenchmark.scala
+++ b/src/test/scala/com/bwsw/tstreams/benchmark/ProducerBenchmark.scala
@@ -52,24 +52,24 @@ class ProducerBenchmark(address: String,
   /**
     * Measures time of [[com.bwsw.tstreams.agents.producer.Producer]]'s methods
     *
-    * @param iterations         amount of measurements
-    * @param dataSize           size of data sent in each transaction
-    * @param cancelTransactions if true, each transaction will be cancelled,
-    *                           otherwise a checkpoint will be performed for each transaction
-    * @param progressReportRate progress will be printed to the console after this number of iterations
+    * @param iterations            amount of measurements
+    * @param dataSize              size of data sent in each transaction
+    * @param cancelEachTransaction if true, each transaction will be cancelled,
+    *                              otherwise a checkpoint will be performed for each transaction
+    * @param progressReportRate    progress will be printed to the console after this number of iterations
     * @return measurement result
     */
   def run(iterations: Int,
           dataSize: Int = 100,
-          cancelTransactions: Boolean = false,
+          cancelEachTransaction: Boolean = false,
           progressReportRate: Int = 1000): ProducerBenchmark.Result = {
     val producer = factory.getProducer(stream, (0 until partitions).toSet)
     val data = (1 to dataSize).map(_.toByte).toArray
 
     val newTransaction = new ExecutionTimeMeasurement
     val send = createTimeMeasurementIf(dataSize > 0)
-    val checkpoint = createTimeMeasurementIf(!cancelTransactions)
-    val cancel = createTimeMeasurementIf(cancelTransactions)
+    val checkpoint = createTimeMeasurementIf(!cancelEachTransaction)
+    val cancel = createTimeMeasurementIf(cancelEachTransaction)
     val progressBar =
       if (progressReportRate > 0) Some(new ProgressBar(iterations))
       else None

--- a/src/test/scala/com/bwsw/tstreams/benchmark/ProducerBenchmarkRunner.scala
+++ b/src/test/scala/com/bwsw/tstreams/benchmark/ProducerBenchmarkRunner.scala
@@ -28,7 +28,7 @@ import org.rogach.scallop.{ScallopConf, ScallopOption}
   * -a, --address - ZooKeeper address;
   * -t, --token - authentication token;
   * -p, --prefix - path to master node in ZooKeeper;
-  * -c, --cancel - if set, each transaction will be cancelled,
+  * --cancel - if set, each transaction will be cancelled,
   * otherwise a checkpoint will be performed for each transaction;
   * --stream - stream name (test by default);
   * --partitions - amount of partitions on stream (1 by default);
@@ -50,7 +50,7 @@ object ProducerBenchmarkRunner extends App {
   private val result = benchmark.run(
     config.iterations(),
     dataSize = config.dataSize(),
-    cancelTransactions = config.cancel())
+    cancelEachTransaction = config.cancel())
   benchmark.close()
 
   println(("method" +: ExecutionTimeMeasurement.Result.fields).mkString(", "))
@@ -69,9 +69,9 @@ object ProducerBenchmarkRunner extends App {
     val prefix: ScallopOption[String] = opt[String](required = true, short = 'p')
     val stream: ScallopOption[String] = opt[String](default = Some("test"))
     val partitions: ScallopOption[Int] = opt[Int](default = Some(1))
-    val iterations: ScallopOption[Int] = opt[Int](default = Some(10000))
+    val iterations: ScallopOption[Int] = opt[Int](default = Some(100000))
     val dataSize: ScallopOption[Int] = opt[Int](default = Some(100))
-    val cancel: ScallopOption[Boolean] = opt[Boolean](short = 'c')
+    val cancel: ScallopOption[Boolean] = opt[Boolean]()
 
     verify()
   }

--- a/src/test/scala/com/bwsw/tstreams/benchmark/ProducerBenchmarkRunner.scala
+++ b/src/test/scala/com/bwsw/tstreams/benchmark/ProducerBenchmarkRunner.scala
@@ -28,6 +28,8 @@ import org.rogach.scallop.{ScallopConf, ScallopOption}
   * -a, --address - ZooKeeper address;
   * -t, --token - authentication token;
   * -p, --prefix - path to master node in ZooKeeper;
+  * -c, --cancel - if set, each transaction will be cancelled,
+  * otherwise a checkpoint will be performed for each transaction;
   * --stream - stream name (test by default);
   * --partitions - amount of partitions on stream (1 by default);
   * --iterations - amount of measurements (100000 by default);
@@ -45,7 +47,10 @@ object ProducerBenchmarkRunner extends App {
     stream = config.stream(),
     partitions = config.partitions())
 
-  private val result = benchmark.run(config.iterations(), dataSize = config.dataSize())
+  private val result = benchmark.run(
+    config.iterations(),
+    dataSize = config.dataSize(),
+    cancelTransactions = config.cancel())
   benchmark.close()
 
   println(("method" +: ExecutionTimeMeasurement.Result.fields).mkString(", "))
@@ -66,6 +71,8 @@ object ProducerBenchmarkRunner extends App {
     val partitions: ScallopOption[Int] = opt[Int](default = Some(1))
     val iterations: ScallopOption[Int] = opt[Int](default = Some(10000))
     val dataSize: ScallopOption[Int] = opt[Int](default = Some(100))
+    val cancel: ScallopOption[Boolean] = opt[Boolean](short = 'c')
+
     verify()
   }
 


### PR DESCRIPTION
Add flag '-c' to use cancel() instead checkpoint(), e.g.
`sbt "test:runMain com.bwsw.tstreams.benchmark.ProducerBenchmarkRunner -a localhost:2181 -t benchmark -p /tts/master" -c`